### PR TITLE
Extend Node for multiple sensor using one node.

### DIFF
--- a/analog-alarm/analog-alarm.js
+++ b/analog-alarm/analog-alarm.js
@@ -5,9 +5,12 @@ module.exports = function(RED) {
         node.on('input', function(msg) {
             // Create context
             let nodeContext = node.context()
+			
+			// base name of the sensor to group the stored context information for this specific sensor
+			let sensor = msg.topic || 'internals'
 
             // fetch stored limits object or default
-            let limits = nodeContext.get("limits") || {hysteresis: 0.5}
+            let limits = nodeContext.get(sensor+'.limits') || {hysteresis: 0.5}
 
             // check if incoming message contains limits, if so, update context
             if (msg.payload.hihiLimit != null) {
@@ -29,7 +32,7 @@ module.exports = function(RED) {
             if (msg.payload.hysteresis != null) {
                 limits.hysteresis = msg.payload.hysteresis
             }
-            nodeContext.set('limits', limits)
+            nodeContext.set(sensor+'.limits', limits)
 
             // get alarm status
             const defaultAlarmStatus = {
@@ -38,7 +41,7 @@ module.exports = function(RED) {
                 loAlarm : false,
                 loloAlarm : false
             }
-            const alarmStatus = nodeContext.get('alarms') || defaultAlarmStatus
+            const alarmStatus = nodeContext.get(sensor+'.alarms') || defaultAlarmStatus
             
             if (msg.payload.value != null) {
                 // set alarm state
@@ -73,7 +76,7 @@ module.exports = function(RED) {
                 }
                 
                 // Save alarm status in context
-                nodeContext.set('alarms', alarmStatus)
+                nodeContext.set(sensor+'.alarms', alarmStatus)
             }
 
             // return object

--- a/analog-alarm/analog-alarm.js
+++ b/analog-alarm/analog-alarm.js
@@ -5,12 +5,12 @@ module.exports = function(RED) {
         node.on('input', function(msg) {
             // Create context
             let nodeContext = node.context()
-			
-			// base name of the sensor to group the stored context information for this specific sensor
-			let sensor = msg.topic || 'internals'
+            
+            // base name of the sensor to group the stored context information for this specific sensor
+            const sensor = msg.topic || 'internals'
 
             // fetch stored limits object or default
-            let limits = nodeContext.get(sensor+'.limits') || {hysteresis: 0.5}
+            let limits = nodeContext.get(sensor + '.limits') || {hysteresis: 0.5}
 
             // check if incoming message contains limits, if so, update context
             if (msg.payload.hihiLimit != null) {
@@ -32,7 +32,7 @@ module.exports = function(RED) {
             if (msg.payload.hysteresis != null) {
                 limits.hysteresis = msg.payload.hysteresis
             }
-            nodeContext.set(sensor+'.limits', limits)
+            nodeContext.set(sensor + '.limits', limits)
 
             // get alarm status
             const defaultAlarmStatus = {
@@ -41,7 +41,7 @@ module.exports = function(RED) {
                 loAlarm : false,
                 loloAlarm : false
             }
-            const alarmStatus = nodeContext.get(sensor+'.alarms') || defaultAlarmStatus
+            const alarmStatus = nodeContext.get(sensor + '.alarms') || defaultAlarmStatus
             
             if (msg.payload.value != null) {
                 // set alarm state
@@ -76,7 +76,7 @@ module.exports = function(RED) {
                 }
                 
                 // Save alarm status in context
-                nodeContext.set(sensor+'.alarms', alarmStatus)
+                nodeContext.set(sensor + '.alarms', alarmStatus)
             }
 
             // return object


### PR DESCRIPTION
Hello Sindre,

Thank you again for responding to my email and making the repository public. I really liked your implementation as it allows assembling a message with all the data and having a complete output.

In my particular application, I am receiving multiple sensors within a message, and with the help of the "Split" node, I separate them into multiple messages where the topic corresponds to the sensor being analyzed.

Looking at your code, I noticed that you use the context variable "alarms" to store the previous state and perform hysteresis analysis there. To maintain consistency among multiple sensors, I grouped the context into an object where the name is the message topic corresponding to a particular sensor. In case the topic is absent, a generic name called "internals" is used.

Thinking as I write, a problem would arise if the message topic is randomly generated without considering that it is used as context for alarm analysis.

